### PR TITLE
CrateTestCluster fails to run on windows

### DIFF
--- a/src/main/java/io/crate/testing/CrateTestServer.java
+++ b/src/main/java/io/crate/testing/CrateTestServer.java
@@ -22,7 +22,6 @@
 package io.crate.testing;
 
 import org.junit.rules.ExternalResource;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +29,7 @@ import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -184,7 +184,12 @@ public class CrateTestServer extends ExternalResource {
 
         String[] command = new String[settingsMap.size() + 1];
         int idx = 0;
-        command[idx++] = "bin/crate";
+
+        String executable = Paths.get(workingDir.toString() , "bin" , "crate").toString();
+        if (isWindows()) {
+            executable = executable.concat(".bat");
+        }
+        command[idx++] = executable;
 
         for (Map.Entry<String, Object> entry : settingsMap.entrySet()) {
             command[idx++] = String.format(Locale.ENGLISH, "-Des.%s=%s", entry.getKey(), entry.getValue());
@@ -238,6 +243,10 @@ public class CrateTestServer extends ExternalResource {
                 }
             }
         });
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).indexOf("win")>=0;
     }
 
 }


### PR DESCRIPTION
CrateTestCluster fails to run if used on windows there is two problems 
1) executable path relative to working directory but must be absolute 
2) no .bat extension which makes windows trying to run bash script which is not valid executable file 

