### PR TITLE
Remove Builder from CrateTestServer

### DIFF
--- a/src/main/java/io/crate/testing/CrateTestCluster.java
+++ b/src/main/java/io/crate/testing/CrateTestCluster.java
@@ -40,12 +40,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
@@ -190,15 +185,15 @@ public class CrateTestCluster extends ExternalResource {
 
         String[] unicastHosts = getUnicastHosts(hostAddress, transportPorts);
         for (int i = 0; i < numberOfNodes; i++) {
-            servers[i] = new CrateTestServer.Builder()
-                    .clusterName(clusterName)
-                    .workingDir(crateWorkingDir())
-                    .host(hostAddress)
-                    .httpPort(httpPorts[i])
-                    .transportPort(transportPorts[i])
-                    .settings(settings)
-                    .addUnicastHosts(unicastHosts)
-                    .build();
+            servers[i] = new CrateTestServer(
+                    clusterName,
+                    httpPorts[i],
+                    transportPorts[i],
+                    crateWorkingDir(),
+                    hostAddress,
+                    settings,
+                    unicastHosts
+            );
         }
         return servers;
     }

--- a/src/main/java/io/crate/testing/CrateTestServer.java
+++ b/src/main/java/io/crate/testing/CrateTestServer.java
@@ -53,58 +53,6 @@ public class CrateTestServer extends ExternalResource {
     private ExecutorService executor;
     private Process crateProcess;
 
-    static class Builder {
-        private String host = InetAddress.getLoopbackAddress().getHostAddress();
-        private int httpPort = Utils.randomAvailablePort();
-        private int transportPort = Utils.randomAvailablePort();
-        private Path workingDir = CrateTestCluster.TMP_WORKING_DIR;
-        private String clusterName = "Testing-" + transportPort;
-        private List<String> unicastHosts = new ArrayList<>();
-        private Map<String, Object> nodeSettings = Collections.emptyMap();
-
-        Builder() {
-        }
-
-        public Builder host(String host) {
-            this.host = host;
-            return this;
-        }
-
-        public Builder httpPort(int httpPort) {
-            this.httpPort = httpPort;
-            return this;
-        }
-
-        public Builder transportPort(int transportPort) {
-            this.transportPort = transportPort;
-            return this;
-        }
-
-        public Builder workingDir(Path workingDir) {
-            this.workingDir = workingDir;
-            return this;
-        }
-
-        public Builder clusterName(String clusterName) {
-            this.clusterName = clusterName;
-            return this;
-        }
-
-        public Builder addUnicastHosts(String... unicastHosts) {
-            Collections.addAll(this.unicastHosts, unicastHosts);
-            return this;
-        }
-
-        public Builder settings(Map<String, Object> nodeSettings) {
-            this.nodeSettings = nodeSettings;
-            return this;
-        }
-
-        public CrateTestServer build() {
-            return new CrateTestServer(clusterName, httpPort, transportPort, workingDir, host,
-                    nodeSettings, unicastHosts.toArray(new String[unicastHosts.size()]));
-        }
-    }
 
     public int httpPort() {
         return httpPort;
@@ -122,13 +70,13 @@ public class CrateTestServer extends ExternalResource {
         return clusterName;
     }
 
-    private CrateTestServer(String clusterName,
-                            int httpPort,
-                            int transportPort,
-                            Path workingDir,
-                            String host,
-                            Map<String, Object> settings,
-                            String... unicastHosts) {
+    public CrateTestServer(String clusterName,
+                           int httpPort,
+                           int transportPort,
+                           Path workingDir,
+                           String host,
+                           Map<String, Object> settings,
+                           String... unicastHosts) {
         this.clusterName = Utils.firstNonNull(clusterName, "Testing-" + transportPort);
         this.crateHost = host;
         this.httpPort = httpPort;

--- a/src/test/java/io/crate/testing/ClusterTest.java
+++ b/src/test/java/io/crate/testing/ClusterTest.java
@@ -89,6 +89,7 @@ public class ClusterTest extends BaseTest {
         Path workingPath = testCluster.crateWorkingDir();
         assertThat(Files.exists(workingPath), is(true));
 
+
         testCluster.after();
         assertThat(Files.exists(workingPath), is(true));
     }


### PR DESCRIPTION
The Builder always allocated two extra ports which were never used. In
fact the only usage of the builder used all setters anyway.