### PR TITLE
Make before and after public

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+ * Made the CrateTestCluster before & after methods public
+
 2016/03/14 0.4.1
 ================
 

--- a/src/main/java/io/crate/testing/CrateTestCluster.java
+++ b/src/main/java/io/crate/testing/CrateTestCluster.java
@@ -262,8 +262,11 @@ public class CrateTestCluster extends ExternalResource {
         return new JsonParser().parse(res.toString()).getAsJsonObject();
     }
 
+    /**
+     * launches the crate server and waits for them to become ready
+     */
     @Override
-    protected void before() throws Throwable {
+    public void before() throws Throwable {
         prepareCrateEnvironment();
         servers = buildServers();
         for (CrateTestServer server : servers) {
@@ -338,8 +341,11 @@ public class CrateTestCluster extends ExternalResource {
         );
     }
 
+    /**
+     * stops the crate server and removes the workingDir if keepWorkingDir is false
+     */
     @Override
-    protected void after() {
+    public void after() {
         CrateTestServer[] localServers = serversSafe();
         for (CrateTestServer server : localServers) {
             server.after();


### PR DESCRIPTION
In order to make it possible for users of the CrateTestCluster to add
plugins before the server are launched