### PR TITLE
fixes the content type when doing HTTP request

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+ * Fixed used content-type header, CrateDB > 2.3.x won't accept request with
+   wrong content-type header anymore.
+
 2017/07/03 0.6.0
 ================
 

--- a/src/main/java/io/crate/testing/CrateTestCluster.java
+++ b/src/main/java/io/crate/testing/CrateTestCluster.java
@@ -266,7 +266,7 @@ public class CrateTestCluster extends ExternalResource {
 
         String query = "{\"stmt\": \"select count(*) as nodes from sys.nodes\"}";
         byte[] body = query.getBytes("UTF-8");
-        connection.setRequestProperty("Content-Type", "application/text");
+        connection.setRequestProperty("Content-Type", "application/json");
         connection.setRequestProperty("Content-Length", String.valueOf(body.length));
         connection.setDoOutput(true);
         connection.getOutputStream().write(body);


### PR DESCRIPTION
Since CrateDB > 2.3 (ES6), it is required to send the correct content-type header “application/json”. 
Server responses with a 406 error code otherwise.