### PR TITLE
Rename id for bintray repository to not mixup with mvn central.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+ * Changed bintray repository ``id`` from ``central` to ``bintray`` to avoid
+   mixup with maven central repository.
+
 2018/02/13 0.6.1
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ repository to your ``pom.xml``:
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>central</id>
+            <id>bintray</id>
             <name>bintray</name>
             <url>http://dl.bintray.com/crate/crate</url>
         </repository>


### PR DESCRIPTION
Fixes: https://github.com/crate/crate-java-testing/issues/46