### PR TITLE
Fixes the content type for BaseTest when doing HTTP request.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+ * Fixed used content-type header for BaseTest, CrateDB > 2.3.x won't accept
+   requests with wrong content-type header anymore.
+
  * Changed bintray repository ``id`` from ``central` to ``bintray`` to avoid
    mixup with maven central repository.
 

--- a/src/test/java/io/crate/integrationtests/BaseTest.java
+++ b/src/test/java/io/crate/integrationtests/BaseTest.java
@@ -62,7 +62,7 @@ public abstract class BaseTest extends RandomizedTest {
 
         String query = "{\"stmt\": \"" + statement + "\"}";
         byte[] body = query.getBytes("UTF-8");
-        connection.setRequestProperty("Content-Type", "application/text");
+        connection.setRequestProperty("Content-Type", "application/json");
         connection.setRequestProperty("Content-Length", String.valueOf(body.length));
         connection.setDoOutput(true);
         connection.getOutputStream().write(body);


### PR DESCRIPTION
Since CrateDB > 2.3 (ES6), it is required to send the correct
content-type header “application/json”.
Server responses with a 406 error code otherwise.