### PR TITLE
PR against issue 64

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+* Upgraded dependencies to latest stable versions.
+
 2019/05/20 0.7.0
 ================
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -23,6 +23,13 @@ Run the unit tests like so::
 
 .. _Gradle: https://gradle.org/
 
+Vulnerability Check
+===================
+
+Dependencies can be checked for known vulnerabilities by running::
+
+    $ ./gradlew dependencyCheckAnalyze
+
 Preparing a Release
 ===================
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.owasp:dependency-check-gradle:5.3.0'
+    }
+}
+
 plugins {
     id 'idea'
     id 'java'
@@ -23,6 +32,8 @@ dependencies {
         exclude group: 'junit', module: 'junit'
     }
 }
+
+apply plugin: 'org.owasp.dependencycheck'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = "1.8"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Testing
-junitVersion = 4.12
-randomizedTestingVersion = 2.1.11
+junitVersion = 4.13
+randomizedTestingVersion = 2.7.6
 gsonVersion = 2.8.6
-commons_compressVersion = 1.4.1
+commons_compressVersion = 1.19
 
 # Project wide version
 version=0.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Testing
-junitVersion = 4.11
+junitVersion = 4.12
 randomizedTestingVersion = 2.1.11
-gsonVersion = 1.7.2
-commons_compressVersion = 1.2
+gsonVersion = 2.8.6
+commons_compressVersion = 1.4.1
 
 # Project wide version
 version=0.7.0

--- a/src/test/java/io/crate/integrationtests/FromFileTest.java
+++ b/src/test/java/io/crate/integrationtests/FromFileTest.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class FromFileTest extends BaseTest {

--- a/src/test/java/io/crate/integrationtests/FromLatestUrlTest.java
+++ b/src/test/java/io/crate/integrationtests/FromLatestUrlTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 
 import java.net.MalformedURLException;
 
-import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FromLatestUrlTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/FromURLPropertyClusterTest.java
+++ b/src/test/java/io/crate/integrationtests/FromURLPropertyClusterTest.java
@@ -34,6 +34,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FromURLPropertyClusterTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/FromUrlTest.java
+++ b/src/test/java/io/crate/integrationtests/FromUrlTest.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FromUrlTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/FromVersionPropertyClusterTest.java
+++ b/src/test/java/io/crate/integrationtests/FromVersionPropertyClusterTest.java
@@ -34,6 +34,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FromVersionPropertyClusterTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/FromVersionTest.java
+++ b/src/test/java/io/crate/integrationtests/FromVersionTest.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FromVersionTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/MultipleDifferentCratesTest.java
+++ b/src/test/java/io/crate/integrationtests/MultipleDifferentCratesTest.java
@@ -28,6 +28,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultipleDifferentCratesTest extends BaseTest {
 

--- a/src/test/java/io/crate/integrationtests/ReuseStaticClusterInstanceTest.java
+++ b/src/test/java/io/crate/integrationtests/ReuseStaticClusterInstanceTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * testing multiple starts and stops of a crate test cluster

--- a/src/test/java/io/crate/integrationtests/SimpleIntegrationTest.java
+++ b/src/test/java/io/crate/integrationtests/SimpleIntegrationTest.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SimpleIntegrationTest extends BaseTest {
 

--- a/src/test/java/io/crate/testing/ClusterTest.java
+++ b/src/test/java/io/crate/testing/ClusterTest.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import static io.crate.testing.Constants.CRATE_VERSION_FOR_TESTS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class ClusterTest extends BaseTest {

--- a/src/test/java/io/crate/testing/CrateTestServerTests.java
+++ b/src/test/java/io/crate/testing/CrateTestServerTests.java
@@ -24,23 +24,27 @@ package io.crate.testing;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class CrateTestServerTests extends RandomizedTest {
 
 
-    private CrateTestServer serverOf(String version) {
+    private CrateTestServer serverOf(String version) throws IOException {
         return new CrateTestServer(
                 "test-cluster",
                 4200,
                 4300,
                 5432,
-                newTempDir().toPath(),
+                newTempDir().toAbsolutePath(),
                 "localhost",
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -50,7 +54,7 @@ public class CrateTestServerTests extends RandomizedTest {
     }
 
     @Test
-    public void testPrepareSettingsForAnyVersion() {
+    public void testPrepareSettingsForAnyVersion() throws Exception {
         CrateTestServer server = serverOf("0.0.0");
         Map<String, Object> settings = server.prepareSettings();
 
@@ -63,7 +67,7 @@ public class CrateTestServerTests extends RandomizedTest {
     }
 
     @Test
-    public void testPrepareSettingsForLt2_0() {
+    public void testPrepareSettingsForLt2_0() throws Exception {
         CrateTestServer server = serverOf("1.0.0");
         Map<String, Object> settings = server.prepareSettings();
 
@@ -72,7 +76,7 @@ public class CrateTestServerTests extends RandomizedTest {
     }
 
     @Test
-    public void testPrepareSettingsForLt4_0() {
+    public void testPrepareSettingsForLt4_0() throws Exception {
         CrateTestServer server = serverOf("3.0.0");
         Map<String, Object> settings = server.prepareSettings();
 
@@ -80,7 +84,7 @@ public class CrateTestServerTests extends RandomizedTest {
     }
 
     @Test
-    public void testPrepareSettingsForGte4_0() {
+    public void testPrepareSettingsForGte4_0() throws Exception {
         CrateTestServer server = serverOf("4.0.0");
         Map<String, Object> settings = server.prepareSettings();
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Vulnerability detected in a particular version in build.gradle - Issue 64 - https://github.com/crate/crate-java-testing/issues/64

Primarily had to update apache.commons-compress version to 1.4.1
But also updated Junit version to 4.12 and gson version to 2.8.6
All tests were passing except for the one, I have created another PR.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
