### PR TITLE
Make bundled jdk java executable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+* Added support for CrateDB tarballs with bundled JDK.
+
 2020/02/05 0.8.0
 ================
 

--- a/src/main/java/io/crate/testing/Utils.java
+++ b/src/main/java/io/crate/testing/Utils.java
@@ -143,12 +143,10 @@ public class Utils {
         // tarIn is a TarArchiveInputStream
         while (tarEntry != null) {
             Path entryPath = Paths.get(tarEntry.getName());
-
             if (entryPath.getNameCount() == 1) {
                 tarEntry = tarIn.getNextTarEntry();
                 continue;
             }
-
             Path strippedPath = entryPath.subpath(1, entryPath.getNameCount());
             File destPath = new File(dest, strippedPath.toString());
 
@@ -157,15 +155,15 @@ public class Utils {
             } else {
                 destPath.createNewFile();
                 byte[] btoRead = new byte[1024];
-                BufferedOutputStream bout =
-                        new BufferedOutputStream(new FileOutputStream(destPath));
-                int len;
-                while ((len = tarIn.read(btoRead)) != -1) {
-                    bout.write(btoRead, 0, len);
+                try (BufferedOutputStream bout = new BufferedOutputStream(new FileOutputStream(destPath))) {
+                    int len;
+                    while ((len = tarIn.read(btoRead)) != -1) {
+                        bout.write(btoRead, 0, len);
+                    }
                 }
-
-                bout.close();
-                if (destPath.getParent().equals(dest.getPath() + "/bin")) {
+                if (destPath.getPath().endsWith("bin/crate")) {
+                    destPath.setExecutable(true);
+                } else if (destPath.getPath().endsWith("/jdk/bin/java")) {
                     destPath.setExecutable(true);
                 }
             }


### PR DESCRIPTION
Using the latest nightlies led to a permission denied error because
`jdk/bin/java` wasn't flagged as executable.

Related to https://github.com/crate/crate/issues/9754