### PR TITLE
Fix permission issue for JDK on MacOS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate-Java-Testing
 Unreleased
 ==========
 
+* Fixed permission issue on CrateDB tarballs with bundled JDK on MacOS.
+
 2020/03/20 0.9.0
 ================
 

--- a/src/main/java/io/crate/testing/Utils.java
+++ b/src/main/java/io/crate/testing/Utils.java
@@ -163,7 +163,7 @@ public class Utils {
                 }
                 if (destPath.getPath().endsWith("bin/crate")) {
                     destPath.setExecutable(true);
-                } else if (destPath.getPath().endsWith("/jdk/bin/java")) {
+                } else if (destPath.getPath().endsWith("/bin/java")) {
                     destPath.setExecutable(true);
                 }
             }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

On MacOS (Darwin) the java executable is located at `jdk/Contents/Home/bin/java` and must be set executable.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
