### PR TITLE
Fix gradle sign/publish configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,19 +66,6 @@ wrapper {
     gradleVersion = '7.0'
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir 'src/main/java'
-        }
-    }
-    test {
-        resources {
-            srcDir 'src/test/java'
-            include '**/*.tar.gz'
-        }
-    }
-}
 
 jar {
     archiveBaseName = 'crate-testing'
@@ -136,4 +123,9 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    required { gradle.taskGraph.hasTask("publish") }
+    sign publishing.publications.mavenJava
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
 description = 'Crate Testing'
@@ -114,13 +115,13 @@ publishing {
             }
         }
     }
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            credentials {
-                username = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
-                password = project.hasProperty('sonatypePassword') ? sonatypePassword : ""
-            }
+        sonatype {
+            username = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
+            password = project.hasProperty('sonatypePassword') ? sonatypePassword : ""
         }
     }
 }


### PR DESCRIPTION
The publish step failed because of duplicate entries due to the
sourceSets definition.

We also have to sign the package
