### PR TITLE
Remove travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-jdk: openjdk11
-
-sudo: false
-
-script: ./gradlew test
-
-notifications:
-  email: false


### PR DESCRIPTION
Tests are run with GHA now (https://github.com/crate/crate-java-testing/pull/79) plus travis-ci.org was shut down and tests are no longer executed there

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
