### PR TITLE
Handle extraction of tarball without explicit folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api "junit:junit:$junitVersion"
     implementation "org.apache.commons:commons-compress:$commons_compressVersion"
     implementation "com.google.code.gson:gson:$gsonVersion"
+    implementation "org.hamcrest:hamcrest-core:2.2"
 
     testImplementation ("com.carrotsearch.randomizedtesting:randomizedtesting-runner:$randomizedTestingVersion") {
         exclude group: 'junit', module: 'junit'


### PR DESCRIPTION
Maven creates tarballs without an explicit folder entry.

The first entry is:

    crate-.../CHANGES.txt

Instead of:

    crate-.../

This adds a `mkdirs()` call, to ensure parent folders for files are
always created.

No new test, because `FromLatestUrlTest` already failed
