### PR TITLE
Add signing config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ idea {
 }
 
 wrapper {
-    gradleVersion = '7.0'
+    gradleVersion = '8.3'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 
 description = 'Crate Testing'
@@ -128,6 +128,6 @@ nexusPublishing {
 }
 
 signing {
-    required { gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
+    useGpgCmd()
+    sign(publishing.publications)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ gsonVersion = 2.8.6
 commons_compressVersion = 1.19
 
 # Project wide version
-version=0.11.0
+version=0.11.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The `closeSonatypeStagingRepository` release task fails otherwise.
The nexus/oss.sonatype.org web ui shows errors like these:

    failureMessage	Missing Signature: '/io/crate/crate-testing/0.11.0/crate-testing-0.11.0.pom.asc' does not exist for 'crate-testing-0.11.0.pom'.
