### PR TITLE
Use in-memory ascii-armored keys instead of using the gpg agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,8 @@ nexusPublishing {
 }
 
 signing {
-    useGpgCmd()
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications)
 }


### PR DESCRIPTION
Follow up of #85.

This setup was successfully tested on a jenkins slave with the required environment variables set.

Depends on https://github.com/crate/jenkins-dsl/pull/1250
