### PR TITLE
Automatically determine appropriate URL based off platform in VersionDownloadSource

### DIFF
--- a/src/main/java/io/crate/testing/download/VersionDownloadSource.java
+++ b/src/main/java/io/crate/testing/download/VersionDownloadSource.java
@@ -28,7 +28,14 @@ import java.util.Locale;
 
 class VersionDownloadSource implements DownloadSource {
 
-    public static final String VERSION_DOWNLOAD_URL =  "https://cdn.crate.io/downloads/releases/crate-%s.tar.gz";
+    public static final String RELEASE_URL = "https://cdn.crate.io/downloads/releases/crate-%s.tar.gz";
+    public static final String RELEASE_PLATFORM_URL = "https://cdn.crate.io/downloads/releases/cratedb/%s/crate-%s.tar.gz";
+    public static final String NIGHTLY_URL = "https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz";
+    public static final String NIGHTLY_PLATFORM_URL = "https://cdn.crate.io/downloads/releases/nightly/%s/crate-latest.tar.gz";
+    public static final String X64_LINUX = "x64_linux";
+    public static final String X64_WINDOWS = "x64_windows";
+    public static final String AARCH64_LINUX = "aarch64_linux";
+    public static final String AARCH64_MAC = "aarch64_mac";
 
     private final String version;
     private final String folderName;
@@ -45,7 +52,58 @@ class VersionDownloadSource implements DownloadSource {
 
     @Override
     public URL downloadUrl() throws MalformedURLException {
-        return new URL(String.format(Locale.ENGLISH, VERSION_DOWNLOAD_URL, version));
+        return buildDownloadUrl(this.version, platform(
+                System.getProperty("os.name"),
+                System.getProperty("os.arch")));
+    }
+
+    static URL buildDownloadUrl(String version, String platform) throws MalformedURLException {
+        if (version.equals("latest") || version.equals("nightly")) {
+            switch (platform) {
+                case AARCH64_MAC:
+                case AARCH64_LINUX:
+                    return new URL(String.format(Locale.ENGLISH, NIGHTLY_PLATFORM_URL, platform));
+                case X64_LINUX:
+                    return new URL(NIGHTLY_URL);
+                default:
+                    throw new MalformedURLException(String.format("Platform %s not supported", platform));
+            }
+        }
+        switch (platform) {
+            // There are currently no aarch64_mac releases besides nightly. Fallback to x64_mac release
+            // which needs an emulation layer (i.e. Rosetta 2)
+            case AARCH64_MAC:
+                return new URL(String.format(Locale.ENGLISH, RELEASE_PLATFORM_URL, "x64_mac", version));
+            case AARCH64_LINUX:
+            case X64_WINDOWS:
+                return new URL(String.format(Locale.ENGLISH, RELEASE_PLATFORM_URL, platform, version));
+            case X64_LINUX:
+                return new URL(String.format(Locale.ENGLISH, RELEASE_URL, version));
+            default:
+                throw new MalformedURLException(String.format("Platform %s not supported", platform));
+        }
+    }
+
+    static String platform(String rawOsName, String rawArchName) {
+        String archName = rawArchName.toLowerCase();
+        String osName = rawOsName.toLowerCase();
+        String os;
+        String arch;
+
+        if (archName.equals("arm") || archName.equals("aarch64")) {
+            arch = "aarch64";
+        } else {
+            arch = "x64";
+        }
+
+        if (osName.equals("mac os x")) {
+            os = "mac";
+        } else if (osName.startsWith("windows")) {
+            os = "windows";
+        } else {
+            os = osName;
+        }
+        return arch + "_" + os;
     }
 
     @Override

--- a/src/test/java/io/crate/testing/download/VersionDownloadSourceTest.java
+++ b/src/test/java/io/crate/testing/download/VersionDownloadSourceTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing.download;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Suite;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        VersionDownloadSourceTest.PlatformTest.class,
+        VersionDownloadSourceTest.BuildDownloadUrlTest.class,
+        VersionDownloadSourceTest.BuildDownloadUrlExceptionsTest.class
+})
+public class VersionDownloadSourceTest {
+
+    @RunWith(Parameterized.class)
+    public static class PlatformTest {
+        @Parameterized.Parameters(name = "OS Name: {0}, Arch: {1}, Expected: {2}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                    { "Mac OS X", "arm", "aarch64_mac" },
+                    { "Mac OS X", "aarch64", "aarch64_mac" },
+                    { "Linux", "x86_64", "x64_linux" },
+                    { "Windows 10", "amd64", "x64_windows" },
+            });
+        }
+
+        private String osName;
+        private String arch;
+        private String expected;
+
+        public PlatformTest(String osName, String arch, String expected) {
+            this.osName = osName;
+            this.arch = arch;
+            this.expected = expected;
+        }
+
+        @Test
+        public void testPlatform() {
+            assertThat(VersionDownloadSource.platform(osName, arch), is(expected));
+        }
+
+    }
+
+    @RunWith(Parameterized.class)
+    public static class BuildDownloadUrlTest {
+        @Parameterized.Parameters(name = "Version: {0}, Platform: {1}, Expected: {2}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                    { "6.4.0", "aarch64_mac",
+                            "https://cdn.crate.io/downloads/releases/cratedb/x64_mac/crate-6.4.0.tar.gz" },
+                    { "6.4.0", "aarch64_linux",
+                            "https://cdn.crate.io/downloads/releases/cratedb/aarch64_linux/crate-6.4.0.tar.gz" },
+                    { "6.4.0", "x64_windows",
+                            "https://cdn.crate.io/downloads/releases/cratedb/x64_windows/crate-6.4.0.tar.gz" },
+                    { "6.4.0", "x64_linux",
+                            "https://cdn.crate.io/downloads/releases/crate-6.4.0.tar.gz" },
+                    { "latest", "aarch64_mac",
+                            "https://cdn.crate.io/downloads/releases/nightly/aarch64_mac/crate-latest.tar.gz" },
+                    { "latest", "aarch64_linux",
+                            "https://cdn.crate.io/downloads/releases/nightly/aarch64_linux/crate-latest.tar.gz" },
+                    { "latest", "x64_linux",
+                            "https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz" },
+            });
+        }
+
+        private String version;
+        private String platform;
+        private String expected;
+
+        public BuildDownloadUrlTest(String version, String platform, String expected) {
+            this.version = version;
+            this.platform = platform;
+            this.expected = expected;
+        }
+
+        @Test
+        public void testBuildDownloadUrl() throws Exception {
+            assertThat(VersionDownloadSource.buildDownloadUrl(version, platform).toString(), is(expected));
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class BuildDownloadUrlExceptionsTest {
+        @Parameterized.Parameters(name = "Version: {0}, Platform: {1}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                    { "latest", "x64_windows" },
+                    { "6.4.0", "x64_sunos" }
+            });
+        }
+
+        private String version;
+        private String platform;
+
+        public BuildDownloadUrlExceptionsTest(String version, String platform) {
+            this.version = version;
+            this.platform = platform;
+        }
+
+        @Test(expected = java.net.MalformedURLException.class)
+        public void testBuildDownloadUrlException() throws Exception {
+            VersionDownloadSource.buildDownloadUrl(version, platform);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Related to this issue: https://github.com/crate/jmx_exporter/issues/102 
Related to PR: https://github.com/crate/jmx_exporter/pull/104 so that jmx_exporter can simply pass a desired CrateDB version for download to crate-java-testing. This PR makes it easier to test different releases on jmx_exporter from different systems, not only Linux.

Currently, `CrateTestCluster.fromVersion` will download from `https://cdn.crate.io/downloads/releases/crate-%s.tar.gz`

However, if the client is running on aarch64_mac, for example, the releases at this URL are not suitable for the client's system. There are releases for specific architectures that should be used instead. For example: https://cdn2.crate.io/downloads/releases/nightly/aarch64_mac/

Currently, the client must work around this by browsing  https://cdn2.crate.io/downloads/releases/ to find the url to the release they want and then call `CrateTestCluster.fromURL`. 

This PR allows the client to simply pass the desired version they want to download and it abstracts away figuring out the appropriate CrateDB release to download.


> [!NOTE]
> This PR does not yet address making tests run locally from aarch64_mac. Further changes would be necessary for that, for example here: 
> https://github.com/crate/crate-java-testing/blob/67b63a4666172b6577c05ceeb813791719510d1c/src/test/java/io/crate/testing/ShutdownTest.java#L9-L20
> This still has a hardcoded URL. The workaround in `DEVELOP.rst` is still necessary if developers want to run local tests on macos

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Related to https://github.com/crate/jmx_exporter/issues/102
