### PR TITLE
Update docs on how to release a new version

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -60,5 +60,8 @@ To create a new release, you must:
 Maven Central Deployment
 ========================
 
-The artifacts can be uploaded to maven central using ``./gradlew uploadArchives closeAndReleaseRepository``.
-This gradle task requires signing and sonatype credentials.
+We deploy the artifcats via a Jenkins job, `crate_java_testing_publish`_.
+Navigate to this site, and run "Build with Parameters" on the master branch, and a new release will be published to `maven central`_.
+
+.. _crate_java_testing_publish_: https://jenkins.crate.io/job/Ecosystem/job/Release/job/Devtools/job/crate_java_testing_publish/
+.. _maven_central_: https://central.sonatype.com/artifact/io.crate/crate-testing


### PR DESCRIPTION

## Summary of the changes / Why this is an improvement

Related to https://github.com/crate/jmx_exporter/issues/102 
Found the docs were out of date while working on https://github.com/crate/crate-java-testing/pull/96 which is for the above issue


We no longer deploy from our local computers. We use this Jenkins job


## Checklist

 - [x] Link to issue this PR refers to (if applicable): Related to https://github.com/crate/jmx_exporter/issues/102
